### PR TITLE
IOSP-5565 - Email - error handling when decryption fails

### DIFF
--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -423,6 +423,19 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   }
 }
 
+- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error
+{
+  if (_onLoadingError) {
+    NSMutableDictionary<NSString *, id> *event = [self baseEvent];
+    [event addEntriesFromDictionary:@{
+                                      @"domain": error.domain,
+                                      @"code": @(error.code),
+                                      @"description": error.localizedDescription,
+                                      }];
+    _onLoadingError(event);
+  }
+}
+
 #pragma mark - WKUIDelegate
 
 - (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler {


### PR DESCRIPTION
## Description
https://perzoinc.atlassian.net/browse/IOSP-5565

## Code:

#### Problem:
There wasn't a simple way to communicate loading failures from the `WKWebView` instance back to the JS land.
 
#### Fix:
Adding support for navigation error handling.

#### Unit Tests
None

## Others:

#### Related PRs
None